### PR TITLE
chore: fix renovate packageRules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,16 @@
   "reviewers": ["bicstone"],
   "packageRules": [
     {
+      "matchPackagePatterns": ["*"],
+      "groupName": "dependencies"
+    },
+    {
       "matchPackagePatterns": ["eslint"],
       "groupName": "eslint dependencies"
     },
     {
       "matchPackagePatterns": ["gatsby"],
       "groupName": "gatsby dependencies"
-    },
-    {
-      "matchPackagePatterns": ["*"],
-      "groupName": "dependencies"
     }
   ]
 }


### PR DESCRIPTION
>Important to know: Renovate will evaluate all packageRules and not stop once it gets a first match. Therefore, you should order your packageRules in order of importance so that later rules can override settings from earlier rules if necessary.

https://docs.renovatebot.com/configuration-options/#packagerules