### PR TITLE
revert: "chore(deps): update pnpm to v10"

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,11 +94,11 @@
   ],
   "volta": {
     "node": "20.18.2",
-    "pnpm": "10.2.1"
+    "pnpm": "9.15.4"
   },
   "engines": {
     "node": "20.18.2",
-    "pnpm": "10.2.1"
+    "pnpm": "9.15.4"
   },
-  "packageManager": "pnpm@10.2.1"
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
Reverts bicstone/portfolio#1227

https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267

```
pnpm run build

> bicstone.me@0.1.0 build /home/runner/work/portfolio/portfolio
> gatsby build

success compile gatsby files - 4.84[9](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:10)s
success load gatsby config - 0.045s
error Error in "/home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp@5.14.0_gatsby@5.14.1_babel-eslint@[10](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:11).1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/gatsby-node": 
Something went wrong installing the "sharp" module

Cannot find module '../build/Release/sharp-linux-x64.node'
Require stack:
- /home/runner/work/portfolio/portfolio/node_modules/.pnpm/sharp@0.32.6/node_modules/sharp/lib/sharp.js
- /home/runner/work/portfolio/portfolio/node_modules/.pnpm/sharp@0.32.6/node_modules/sharp/lib/constructor.js
- /home/runner/work/portfolio/portfolio/node_modules/.pnpm/sharp@0.32.6/node_modules/sharp/lib/index.js
- /home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp@5.14.0_gatsby@5.14.1_babel-eslint@10.1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/safe-sharp.js
- /home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp@5.14.0_gatsby@5.14.1_babel-eslint@10.1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/index.js
- /home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp@5.14.0_gatsby@5.14.1_babel-eslint@10.1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/gatsby-node.js

Possible solutions:
- Install with verbose logging and look for errors: "npm install --ignore-scripts=false --foreground-scripts --verbose sharp"
- Install for the current linux-x64 runtime: "npm install --platform=linux --arch=x64 sharp"
- Consult the installation documentation: https://sharp.pixelplumbing.com/install


  Error:Something went wrong installing the "sharp" module
  Cannot find module '../build/Release/sharp-linux-x64.node'
  Require stack:
  - /home/runner/work/portfolio/portfolio/node_modules/.pnpm/sharp@0.32.6/node_m  odules/sharp/lib/sharp.js
  - /home/runner/work/portfolio/portfolio/node_modules/.pnpm/sharp@0.32.6/node_m  odules/sharp/lib/constructor.js
  - /home/runner/work/portfolio/portfolio/node_modules/.pnpm/sharp@0.32.6/node_m  odules/sharp/lib/index.js
  - /home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp  @5.14.0_gatsby@5.14.1_babel-eslint@10.1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0  530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/safe-sharp.js
  - /home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp  @5.14.0_gatsby@5.14.1_babel-eslint@10.1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0  530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/index.js
  - /home/runner/work/portfolio/portfolio/node_modules/.pnpm/gatsby-plugin-sharp  @5.14.0_gatsby@5.14.1_babel-eslint@10.1.0_eslint@9.19.0_jiti@1.21.6__a5bb0a5e0  530e498822e26048c514ce5/node_modules/gatsby-plugin-sharp/gatsby-node.js
  Possible solutions:
  - Install with verbose logging and look for errors: "npm install --ignore-scri  pts=false --foreground-scripts --verbose sharp"
  - Install for the current linux-x64 runtime: "npm install --platform=linux --a  rch=x64 sharp"
  - Consult the installation documentation: 
https://sharp.pixelplumbing.com/inst
  all
  
  - sharp.js:37 Object.<anonymous>
    [portfolio]/[sharp@0.32.6]/[sharp]/lib/sharp.js:37:9
  
  - loader:1469 Module._compile
    node:internal/modules/cjs/loader:1469:14
  
  - loader:1548 Module._extensions..js
    node:internal/modules/cjs/loader:1548:10
  
  - loader:1288 Module.load
    node:internal/modules/cjs/loader:1288:32
  
  - loader:[11](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:12)04 Module._load
    node:internal/modules/cjs/loader:1104:[12](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:13)
  
  - loader:[13](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:14)11 Module.require
    node:internal/modules/cjs/loader:1311:19
  
  - helpers:179 require
    node:internal/modules/helpers:179:18
  
  - constructor.js:11 Object.<anonymous>
    [portfolio]/[sharp@0.32.6]/[sharp]/lib/constructor.js:11:1
  
  - loader:[14](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:15)69 Module._compile
    node:internal/modules/cjs/loader:1469:14
  
  - loader:[15](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:16)48 Module._extensions..js
    node:internal/modules/cjs/loader:1548:10
  
  - loader:1288 Module.load
    node:internal/modules/cjs/loader:1288:32
  
  - loader:1104 Module._load
    node:internal/modules/cjs/loader:1104:12
  
  - loader:1311 Module.require
    node:internal/modules/cjs/loader:1311:19
  
  - helpers:[17](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:18)9 require
    node:internal/modules/helpers:179:[18](https://github.com/bicstone/portfolio/actions/runs/13220337256/job/36904527267#step:7:19)
  
  - index.js:6 Object.<anonymous>
    [portfolio]/[sharp@0.32.6]/[sharp]/lib/index.js:6:15
  
  - loader:1469 Module._compile
    node:internal/modules/cjs/loader:1469:14
  

not finished load plugins - 0.263s
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```