### PR TITLE
chore: tsconfig を TypeScript 7 互換にする

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,86 +1,37 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+    /* Language and Environment */
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "preserve",
+    "jsxImportSource": "@emotion/react",
 
-    /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ] /* Specify library files to be included in the compilation. */,
-    // "allowJs": true                        /* Allow javascript files to be compiled. */,
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true                         /* Do not emit outputs. */,
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    /* Modules */
+    "module": "preserve",
+    "resolveJsonModule": true,
     "paths": {
       // see gatsby-node.ts
-      "@/constants/*": ["src/constants/*"],
-      "@/content/*": ["content/*"],
-      "@/components/*": ["src/components/*"],
-      "@/features/*": ["src/features/*"],
-      "@/generated/*": ["src/generated/*"],
-      "@/utils/*": ["src/utils/*"],
-      "@/layouts/*": ["src/layouts/*"]
-    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+      "@/constants/*": ["./src/constants/*"],
+      "@/content/*": ["./content/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/features/*": ["./src/features/*"],
+      "@/generated/*": ["./src/generated/*"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/layouts/*": ["./src/layouts/*"]
+    },
 
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    /* Emit */
+    "noEmit": true,
 
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    /* Interop Constraints */
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
 
-    /* Advanced Options */
-    "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "resolveJsonModule": true,
-    "jsxImportSource": "@emotion/react",
-    "ignoreDeprecations": "6.0"
+    /* Type Checking */
+    "strict": true,
+
+    /* Completeness */
+    "skipLibCheck": true
   },
   "exclude": [".cache", "node_modules", "public"],
   "include": ["src/**/*.ts", "src/**/*.tsx", "*.ts", "*.tsx"]


### PR DESCRIPTION
## 概要

TypeScript 7 への更新 (#1508) が tsconfig の削除済みオプションで落ちているため、先に tsconfig 側を対応させます。
本 PR は TypeScript 6 のままでも動作するため、単体でマージできます。

## 背景

#1508 の CI エラー:

```
tsconfig.json(48,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration.
tsconfig.json(49,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
tsconfig.json(52,25): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
```

TypeScript 7 (Go 移植版) は `moduleResolution: node10` / `classic`、`baseUrl`、`outFile`、`target: ES5` を未サポートです。

## 変更内容

- `module` を `commonjs` → `preserve` に変更（`moduleResolution` は既定の `bundler` になる）
  - `tsc` は `--noEmit` の型検査にしか使っておらず、実際のバンドルは Gatsby (webpack) が行うため、
    `bundler` 解決のほうが実態に近い
- `baseUrl` を削除し、`paths` を `./` 始まりの相対パスに変更
- 削除済みオプションを指していた `ignoreDeprecations: "6.0"` を削除
- 2020年頃のテンプレート由来のコメントアウトされた設定を整理

## マージ後

#1508 (TypeScript v7) を rebase して CI を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NokuHzsgo5MLLukQMjACPK