### PR TITLE
chore: pnpm の設定を pnpm-workspace.yaml へ移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,5 @@
     "node": "24.19.0",
     "pnpm": "10.34.3"
   },
-  "packageManager": "pnpm@10.34.3",
-  "pnpm": {
-    "neverBuiltDependencies": []
-  }
+  "packageManager": "pnpm@10.34.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,17 @@
+# pnpm 11 以降、設定は package.json の pnpm フィールドではなく本ファイルから読み込まれる
+# see https://pnpm.io/settings
+
+# 依存パッケージのライフサイクルスクリプトはいずれも不要なため、実行を許可しない
+ignoredBuiltDependencies:
+  - "@parcel/watcher"
+  - core-js
+  - core-js-pure
+  - es5-ext
+  - esbuild
+  - gatsby
+  - gatsby-cli
+  - gatsby-plugin-fix-fouc
+  - lmdb
+  - msgpackr-extract
+  - sharp
+  - workerd


### PR DESCRIPTION
## 概要

pnpm v11 への更新 (#1483) がビルドスクリプトの承認エラーで落ちているため、先に設定側を対応させます。
pnpm 10 でも `pnpm-workspace.yaml` から設定が読まれるため、本 PR は単体でマージできます。

## 背景

#1483 の CI エラー:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
       The following keys were ignored: "pnpm.neverBuiltDependencies".
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.1, core-js-pure@3.45.1,
core-js@3.45.1, es5-ext@0.10.64, esbuild@0.28.1, gatsby-cli@5.16.0, gatsby-plugin-fix-fouc@1.1.3,
gatsby@5.16.1, lmdb@2.5.2, lmdb@2.5.3, msgpackr-extract@3.0.3, sharp@0.32.6, workerd@1.20260811.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 11 では package.json の `pnpm` フィールドが読まれなくなり、未承認のビルドスクリプトが残っているとインストールが失敗します。

## 変更内容

- 実質的に無効だった `pnpm.neverBuiltDependencies: []` を package.json から削除
- `pnpm-workspace.yaml` を追加し、実行を許可しないパッケージを `ignoredBuiltDependencies` に明示

いずれのパッケージも現状ビルドスクリプトが実行されていない状態でビルド・デプロイが成功しているため、挙動は変わりません。

## マージ後

#1483 (pnpm v11) を rebase して CI を確認してください。
pnpm 11 で `ignoredBuiltDependencies` が `allowBuilds` に置き換わっている場合は、そちらへの書き換えが追加で必要になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NokuHzsgo5MLLukQMjACPK