### PR TITLE
fix: ネイティブモジュールのビルドスクリプトを許可する

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,15 @@
-# pnpm 11 以降、設定は package.json の pnpm フィールドではなく本ファイルから読み込まれる
-# see https://pnpm.io/settings
-
-# 依存パッケージのライフサイクルスクリプトはいずれも不要なため、実行を許可しない
-ignoredBuiltDependencies:
+onlyBuiltDependencies:
   - "@parcel/watcher"
-  - core-js
-  - core-js-pure
-  - es5-ext
   - esbuild
-  - gatsby
-  - gatsby-cli
-  - gatsby-plugin-fix-fouc
   - lmdb
   - msgpackr-extract
   - sharp
   - workerd
+
+ignoredBuiltDependencies:
+  - core-js
+  - core-js-pure
+  - es5-ext
+  - gatsby
+  - gatsby-cli
+  - gatsby-plugin-fix-fouc


### PR DESCRIPTION
> [!WARNING]
> main へのデプロイが #1391 (Node.js 24) 以降すべて失敗しています。本 PR で復旧します。

## 症状

```
error Error in ".../gatsby-plugin-sharp/gatsby-node":
Something went wrong installing the "sharp" module

Cannot find module '../build/Release/sharp-linux-x64.node'
```

| デプロイ | 結果 |
| --- | --- |
| #1509 migrate hosting to Cloudflare Workers | success |
| #1510 カスタムドメイン設定 | failure (deploy ステップ、build は成功) |
| #1507 actions/setup-node v7 | success |
| **#1391 Node.js 24** | **failure (build ステップ)** |
| 以降すべて | failure |

## 原因

`sharp` はインストール時に `prebuild-install` で libvips のバイナリを取得します。

```json
"install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)"
```

しかしビルドスクリプトが一切許可されていないため、このスクリプトは実行されません。

これまで動いていたのは、`actions/cache` が復元する pnpm store に過去のバイナリが残っていたためです。
Node.js 24 への更新でキャッシュキーが変わった瞬間に表面化しました。**設定が壊れていたのではなく、キャッシュに隠されていた不具合です。**

なお削除した `pnpm.neverBuiltDependencies: []` は「never-build する対象は無し」という意味で、pnpm 10 の既定 (ビルドは承認制) を変えるものではありませんでした。#1514 でその設定を `ignoredBuiltDependencies` に移しましたが、これも同様にビルドを実行しないため、状況は変わっていませんでした。

## 変更内容

ネイティブバイナリの配置が必要なものと、告知を表示するだけのものを分けます。

### 許可するもの (`onlyBuiltDependencies`)

| パッケージ | スクリプトの内容 |
| --- | --- |
| `sharp` | `prebuild-install` で libvips を取得 |
| `lmdb` | `node-gyp-build-optional-packages` |
| `msgpackr-extract` | `node-gyp-build-optional-packages` |
| `esbuild` | `install.js` が実行バイナリを配置 |
| `workerd` | `install.js` が実行バイナリを配置 |
| `@parcel/watcher` | ファイル監視のネイティブモジュール |

### 許可しないもの (`ignoredBuiltDependencies`)

| パッケージ | スクリプトの内容 |
| --- | --- |
| `core-js` / `core-js-pure` / `es5-ext` | 資金調達の告知を表示するのみ |
| `gatsby` / `gatsby-cli` | テレメトリの告知を表示するのみ |
| `gatsby-plugin-fix-fouc` | `preinstall` が `npx only-allow yarn` のため pnpm では失敗する |

## 検証

ローカル (Node.js 24.19.0 / pnpm 10.34.3 / win32-x64) で確認しました。

```
sharp: Using cached libvips-8.14.5-win32-x64.tar.br
sharp: Integrity check passed for win32-x64
sharp: Creating .../sharp/build/Release
Done
```

```
$ pnpm run build
info Done building in 58.0983036 sec
```

## 補足

#1483 (pnpm 11) では設定キーが `allowBuilds` に統合されるため、本 PR マージ後にそちらも合わせて更新します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NokuHzsgo5MLLukQMjACPK