### PR TITLE
chore: Workers のプレビュー URL を有効にする

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "portfolio",
   "compatibility_date": "2026-08-15",
   "workers_dev": false,
-  "preview_urls": false,
+  "preview_urls": true,
   "routes": [{ "pattern": "bicstone.me", "custom_domain": true }],
   "assets": {
     "directory": "./public",


### PR DESCRIPTION
## 概要

`wrangler.jsonc` の `preview_urls` を `true` にします。

```diff
   "workers_dev": false,
-  "preview_urls": false,
+  "preview_urls": true,
```

デプロイした各バージョンに `<VERSION_PREFIX>-portfolio.<SUBDOMAIN>.workers.dev` の URL が発行され、
本番へ切り替える前に内容を確認できるようになります。

## 明示指定が必要な理由

Wrangler のバージョンによって既定値が変わっています。

| Wrangler | `preview_urls` の既定値 |
| --- | --- |
| v4.34.0 未満 | 常に有効 |
| v4.34.0 〜 v4.44.0 未満 | 常に無効 |
| **v4.44.0 以降** | **`workers_dev` の設定に追従** |

本リポジトリは `workers_dev: false` のため、明示しないとプレビュー URL も無効になります。
`workers_dev` は変更せず、プレビュー URL だけを有効にします。

see https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/

## 確認していただきたい点

> [!IMPORTANT]
> **プレビュー URL は認証なしで公開されます。**
> Cloudflare のドキュメントにも "If Preview URLs have been enabled, they are public and available immediately after version creation." と記載があります。

2025-09-17 に Cloudflare が「workers.dev を無効にしている Worker のプレビュー URL を一斉に無効化する」対応を行っていますが、
その理由は *"users who had intentionally disabled their workers.dev route may not have realized their Worker was still accessible at a separate preview URL"* でした。
`workers_dev: false` にしている意図と、プレビュー URL が公開されることの整合は確認しておいてください。

なお SEO 面では問題になりません。`HeadTemplate.tsx` の canonical が `SITE_METADATA.siteUrl` 固定のため、
プレビュー URL 上でも `https://bicstone.me/...` を指します。

```tsx
const canonical = `${SITE_METADATA.siteUrl}${location.pathname}`;
<link rel="canonical" href={canonical} />
```

非公開にしたい場合は Cloudflare Access でプレビュー URL を保護する方法があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NokuHzsgo5MLLukQMjACPK